### PR TITLE
Include an email address when creating new users

### DIFF
--- a/edx_management_commands/management_commands/management/commands/manage_user.py
+++ b/edx_management_commands/management_commands/management/commands/manage_user.py
@@ -72,12 +72,14 @@ class Command(BaseCommand):
             return self._handle_remove(username, email)
 
         old_groups, new_groups = set(), set()
-        user, created = get_user_model().objects.get_or_create(username=username)
+        user, created = get_user_model().objects.get_or_create(
+            username=username,
+            defaults={'email': email}
+        )
 
         if created:
             user.set_unusable_password()
             self.stderr.write(_('Created new user: "{}"').format(user))
-            self._maybe_update(user, 'email', email)
         else:
             # NOTE, we will not update the email address of an existing user.
             self.stderr.write(_('Found existing user: "{}"').format(user))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='edx-management-commands',
-    version='0.0.1',
+    version='0.1.0',
     description='Reusable automation and configuration utilities for edX Django applications',
     author='edX',
     url='https://github.com/edx/edx-django-extensions',


### PR DESCRIPTION
A uniqueness constraint in production-like environments prevents creating new users without an email address. ECOM-4014.

@jimabramson @feanil please review. Is it worth spinning up a sandbox to test this? I'm not even sure if the uniqueness constraint exists on sandboxes.
